### PR TITLE
RAILS_DEFAULT_LOGGGER is depriciated in Rails 3

### DIFF
--- a/lib/spawner.rb
+++ b/lib/spawner.rb
@@ -17,7 +17,7 @@ module Spawner
   # things to close in child process
   @@resources = []
   # in some environments, logger isn't defined
-  @@logger = defined?(RAILS_DEFAULT_LOGGER) ? RAILS_DEFAULT_LOGGER : Logger.new(STDERR)
+  @@logger = defined?(::Rails.logger) ? ::Rails.logger : Logger.new(STDERR)
   # forked children to kill on exit
   @@punks = []
 


### PR DESCRIPTION
RAILS_DEFAULT_LOGGGER is depriciated in Rails 3 and therefore is nil so Logger.new(STDERR) is only used
this cause explicit logs on every rake task.
