### PR TITLE
More Robust Checks on Logger

### DIFF
--- a/lib/spawner.rb
+++ b/lib/spawner.rb
@@ -17,7 +17,8 @@ module Spawner
   # things to close in child process
   @@resources = []
   # in some environments, logger isn't defined
-  @@logger = defined?(::Rails.logger) ? ::Rails.logger : Logger.new(STDERR)
+  @@logger = defined?(::Rails.logger) && ::Rails.logger
+  @@logger = Logger.new(STDERR)  if !@@logger
   # forked children to kill on exit
   @@punks = []
 

--- a/lib/spawner.rb
+++ b/lib/spawner.rb
@@ -200,6 +200,6 @@ module Spawner
 end
 
 
-ActiveRecord::Base.send     :include, Spawner
-ActionController::Base.send :include, Spawner
-ActiveRecord::Observer.send :include, Spawner
+#ActiveRecord::Base.send     :include, Spawner
+#ActionController::Base.send :include, Spawner
+#ActiveRecord::Observer.send :include, Spawner


### PR DESCRIPTION
I received the following error in my Rails app due to @@logger being nil:

...lib/spawner.rb:37:in `default_options': undefined method`info' for nil:NilClass (NoMethodError)

There was a check to see if Rails.logger is defined, but no check to see if it's nil.  This change fixes that.

Thanks!
